### PR TITLE
Improvement: add optional past tense verb

### DIFF
--- a/src/internal/pdf/pdf.go
+++ b/src/internal/pdf/pdf.go
@@ -18,8 +18,16 @@ const (
 //go:embed fonts/Rubik-Regular.ttf
 var rubikRegular []byte
 
-// Generate a PDF document consisting of the provided `labelText` and the current date
-func GeneratePdf(labelText string) ([]byte, error) {
+const DEFAULT_DATEVERB = "made:"
+
+// Generate a PDF document consisting of the provided `labelText`, optional `dateVerb`, and the current date
+func GeneratePdf(labelText string, dateVerb string) ([]byte, error) {
+
+	// ensure dateVerb isn't empty: if not provided, set to the default value
+	if dateVerb == "" {
+		dateVerb = DEFAULT_DATEVERB
+	}
+
 	// initialize PDF
 	pdf := gopdf.GoPdf{}
 	pdf.Start(gopdf.Config{PageSize: gopdf.Rect{W: PAGE_WIDTH, H: PAGE_HEIGHT}})
@@ -49,14 +57,14 @@ func GeneratePdf(labelText string) ([]byte, error) {
 		return nil, err
 	}
 
-	// write the "made on" date information in the lower-left corner of the document
+	// describe what the date information corresponds to (made, bought, etc) in the lower-left corner of the document
 	pdf.SetXY(PAGE_MARGIN, 57)
 	pdf.SetTextColor(85, 85, 85)
 	err = pdf.SetFont("Rubik-Regular", "", 10)
 	if err != nil {
 		return nil, err
 	}
-	err = pdf.Cell(nil, "made:")
+	err = pdf.Cell(nil, dateVerb)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/pdf/pdf.go
+++ b/src/internal/pdf/pdf.go
@@ -39,20 +39,38 @@ func GeneratePdf(labelText string) ([]byte, error) {
 
 	// write the label text in the upper-left corner of the document
 	pdf.SetXY(PAGE_MARGIN, 10)
-	err = pdf.SetFont("Rubik-Regular", "", 16)
 	pdf.SetTextColor(0, 0, 0)
-	pdf.Cell(nil, labelText)
+	err = pdf.SetFont("Rubik-Regular", "", 16)
+	if err != nil {
+		return nil, err
+	}
+	err = pdf.Cell(nil, labelText)
+	if err != nil {
+		return nil, err
+	}
 
 	// write the "made on" date information in the lower-left corner of the document
 	pdf.SetXY(PAGE_MARGIN, 57)
-	err = pdf.SetFont("Rubik-Regular", "", 10)
 	pdf.SetTextColor(85, 85, 85)
-	pdf.Cell(nil, "made:")
+	err = pdf.SetFont("Rubik-Regular", "", 10)
+	if err != nil {
+		return nil, err
+	}
+	err = pdf.Cell(nil, "made:")
+	if err != nil {
+		return nil, err
+	}
 
 	pdf.SetXY(PAGE_MARGIN, 69)
-	err = pdf.SetFont("Rubik-Regular", "", 12)
 	pdf.SetTextColor(0, 0, 0)
-	pdf.Cell(nil, time.Now().Local().Format(time.DateOnly))
+	err = pdf.SetFont("Rubik-Regular", "", 12)
+	if err != nil {
+		return nil, err
+	}
+	err = pdf.Cell(nil, time.Now().Local().Format(time.DateOnly))
+	if err != nil {
+		return nil, err
+	}
 
 	// write the document to a byte buffer
 	b := bytes.NewBuffer([]byte{})

--- a/src/internal/pdf/pdf_test.go
+++ b/src/internal/pdf/pdf_test.go
@@ -15,9 +15,10 @@ const FILE_PATH = "./tmp"
 func TestPdfGeneration_Simple(t *testing.T) {
 	// define test value(s)
 	labelText := "Lorem ipsum dolor"
+	dateVerb := "bought:"
 
 	// generate PDF as []byte
-	b, err := pdf.GeneratePdf(labelText)
+	b, err := pdf.GeneratePdf(labelText, dateVerb)
 	if err != nil {
 		t.Log("Failed to generate PDF", err.Error())
 		t.Fail()

--- a/src/internal/server/PrintLeftoverLabelController.go
+++ b/src/internal/server/PrintLeftoverLabelController.go
@@ -105,6 +105,11 @@ func (c *PrintLeftoverLabelController) PrintLeftoverLabelHandler(w http.Response
 
 	// ensure the directory to save the PDF to exists
 	absPath, err := filepath.Abs(FILE_PATH)
+	if err != nil {
+		fmt.Println("filepath.Abs error", FILE_PATH)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
 
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(FILE_PATH, os.ModePerm); err != nil {

--- a/src/internal/server/PrintLeftoverLabelController_test.go
+++ b/src/internal/server/PrintLeftoverLabelController_test.go
@@ -89,6 +89,13 @@ var testParams = []testParams_PrintLeftoverLabelHandler{
 		expectedStatusCode: http.StatusBadRequest,
 		expectedMessage:    "invalid quantity: value must be a positive integer\n",
 	},
+	// should fail because the dateVerb has too many characters
+	{
+		reqMethod:          "POST",
+		reqBody:            bytes.NewBufferString(`{"labelText":"Lorem ipsum dolor","quantity":100, "dateVerb":"this is far too long:"}`),
+		expectedStatusCode: http.StatusBadRequest,
+		expectedMessage:    "value for dateVerb has too many characters: try something shorter\n",
+	},
 	// should fail on PDF generation
 	{
 		reqMethod:          "POST",

--- a/src/internal/utils/utils.go
+++ b/src/internal/utils/utils.go
@@ -23,7 +23,7 @@ func MockGeneratePdf(labelText string) ([]byte, error) {
 	}
 
 	if labelText == "PDF GENERATION FAIL - WRITE ERROR" {
-		return nil, errors.New("Error writing PDF")
+		return nil, errors.New("error writing pdf")
 	}
 
 	return pdf, nil

--- a/src/internal/utils/utils.go
+++ b/src/internal/utils/utils.go
@@ -15,7 +15,7 @@ var pdf []byte
 // To induce a failure:
 //   - labelText length > 64 characters
 //   - labelText == "PDF GENERATION FAIL - WRITE ERROR"
-func MockGeneratePdf(labelText string) ([]byte, error) {
+func MockGeneratePdf(labelText string, dateVerb string) ([]byte, error) {
 	fmt.Println("generatePdf mock function called")
 
 	if len(labelText) > 64 {


### PR DESCRIPTION
- introduce a `dateVerb` parameter to the endpoint, allowing the date descriptor to be adjusted ('made:', 'bought:', etc)
- update the tests to accommodate this new param
- fixed some minor linting issues and one missing error handling block