### PR TITLE
tweak: change variable name 'dateVerb' to 'dateDescriptor'

### DIFF
--- a/src/internal/pdf/pdf.go
+++ b/src/internal/pdf/pdf.go
@@ -18,14 +18,14 @@ const (
 //go:embed fonts/Rubik-Regular.ttf
 var rubikRegular []byte
 
-const DEFAULT_DATEVERB = "made:"
+const DEFAULT_DATE_DESCRIPTOR = "made:"
 
-// Generate a PDF document consisting of the provided `labelText`, optional `dateVerb`, and the current date
-func GeneratePdf(labelText string, dateVerb string) ([]byte, error) {
+// Generate a PDF document consisting of the provided `labelText`, optional `dateDescriptor`, and the current date
+func GeneratePdf(labelText string, dateDescriptor string) ([]byte, error) {
 
-	// ensure dateVerb isn't empty: if not provided, set to the default value
-	if dateVerb == "" {
-		dateVerb = DEFAULT_DATEVERB
+	// ensure dateDescriptor isn't empty: if not provided, set to the default value
+	if dateDescriptor == "" {
+		dateDescriptor = DEFAULT_DATE_DESCRIPTOR
 	}
 
 	// initialize PDF
@@ -64,7 +64,7 @@ func GeneratePdf(labelText string, dateVerb string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = pdf.Cell(nil, dateVerb)
+	err = pdf.Cell(nil, dateDescriptor)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/pdf/pdf_test.go
+++ b/src/internal/pdf/pdf_test.go
@@ -15,10 +15,10 @@ const FILE_PATH = "./tmp"
 func TestPdfGeneration_Simple(t *testing.T) {
 	// define test value(s)
 	labelText := "Lorem ipsum dolor"
-	dateVerb := "bought:"
+	dateDescriptor := "bought:"
 
 	// generate PDF as []byte
-	b, err := pdf.GeneratePdf(labelText, dateVerb)
+	b, err := pdf.GeneratePdf(labelText, dateDescriptor)
 	if err != nil {
 		t.Log("Failed to generate PDF", err.Error())
 		t.Fail()

--- a/src/internal/server/PrintLeftoverLabelController.go
+++ b/src/internal/server/PrintLeftoverLabelController.go
@@ -11,11 +11,11 @@ import (
 )
 
 type PrintLeftoverLabelController struct {
-	generatePdf func(labelText string, dateVerb string) ([]byte, error)
+	generatePdf func(labelText string, dateDescriptor string) ([]byte, error)
 	printPdf    func(quantity int, filePathName string) ([]byte, error)
 }
 
-func NewPrintLeftoverLabelController(generatePdf func(lt string, dv string) ([]byte, error), printPdf func(q int, fpn string) ([]byte, error)) *PrintLeftoverLabelController {
+func NewPrintLeftoverLabelController(generatePdf func(lt string, dd string) ([]byte, error), printPdf func(q int, fpn string) ([]byte, error)) *PrintLeftoverLabelController {
 
 	return &PrintLeftoverLabelController{
 		generatePdf: generatePdf,
@@ -24,9 +24,9 @@ func NewPrintLeftoverLabelController(generatePdf func(lt string, dv string) ([]b
 }
 
 type PrintLabelRequestBody struct {
-	LabelText string `json:"labelText"`
-	Quantity  int    `json:"quantity"`
-	DateVerb  string `json:"dateVerb"`
+	LabelText      string `json:"labelText"`
+	Quantity       int    `json:"quantity"`
+	DateDescriptor string `json:"dateDescriptor"`
 }
 
 const FILE_PATH = "./tmp"
@@ -34,7 +34,7 @@ const FILE_PATH = "./tmp"
 // the label itself can only display a few words, so 128 bytes is more than enough for a reasonable request
 // yet it is small enough to very quickly recognize if the request is unreasonably large
 const MAX_REQUEST_BODY_SIZE = 128
-const MAX_DATEVERB_SIZE = 20
+const MAX_DATE_DESCRIPTOR_SIZE = 20
 
 func (c *PrintLeftoverLabelController) PrintLeftoverLabelHandler(w http.ResponseWriter, r *http.Request) {
 	/* -- FAIL FAST -- */
@@ -103,8 +103,8 @@ func (c *PrintLeftoverLabelController) PrintLeftoverLabelHandler(w http.Response
 		return
 	}
 	// this is an optional parameter; if unset, the default is "made:"
-	if len(rb.DateVerb) > MAX_DATEVERB_SIZE {
-		msg := "value for dateVerb has too many characters: try something shorter"
+	if len(rb.DateDescriptor) > MAX_DATE_DESCRIPTOR_SIZE {
+		msg := "value for dateDescriptor has too many characters: try something shorter"
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
@@ -142,7 +142,7 @@ func (c *PrintLeftoverLabelController) PrintLeftoverLabelHandler(w http.Response
 	defer f.Close()
 
 	// generate pdf document as []byte
-	p, err := c.generatePdf(rb.LabelText, rb.DateVerb)
+	p, err := c.generatePdf(rb.LabelText, rb.DateDescriptor)
 	if err != nil {
 		fmt.Println(err)
 		http.Error(w, "Error preparing label for printing", http.StatusInternalServerError)

--- a/src/internal/server/PrintLeftoverLabelController_test.go
+++ b/src/internal/server/PrintLeftoverLabelController_test.go
@@ -81,12 +81,12 @@ func TestPrintLeftoverLabelController(t *testing.T) {
 			ExpectedStatusCode: http.StatusBadRequest,
 			ExpectedMessage:    "invalid quantity: value must be a positive integer\n",
 		},
-		// should fail because the dateVerb has too many characters
+		// should fail because the dateDescriptor has too many characters
 		{
 			ReqMethod:          "POST",
-			ReqBody:            bytes.NewBufferString(`{"labelText":"Lorem ipsum dolor","quantity":100, "dateVerb":"this is far too long:"}`),
+			ReqBody:            bytes.NewBufferString(`{"labelText":"Lorem ipsum dolor","quantity":100, "dateDescriptor":"this is far too long:"}`),
 			ExpectedStatusCode: http.StatusBadRequest,
-			ExpectedMessage:    "value for dateVerb has too many characters: try something shorter\n",
+			ExpectedMessage:    "value for dateDescriptor has too many characters: try something shorter\n",
 		},
 		// should fail on PDF generation
 		{

--- a/src/internal/utils/utils.go
+++ b/src/internal/utils/utils.go
@@ -19,7 +19,7 @@ var pdf []byte
 // To induce a failure:
 //   - labelText length > 64 characters
 //   - labelText == "PDF GENERATION FAIL - WRITE ERROR"
-func MockGeneratePdf(labelText string, dateVerb string) ([]byte, error) {
+func MockGeneratePdf(labelText string, dateDescriptor string) ([]byte, error) {
 	fmt.Println("generatePdf mock function called")
 
 	if len(labelText) > 64 {


### PR DESCRIPTION
Upon some reflection, I realized that `dateVerb` may be an accurate and precise name for the data it represents, `dateDescriptor` feels much more intuitive and maintainable.

Ultimately this feels like a petty PR, but I'd rather make the change now while it's still fresh in my mind.